### PR TITLE
Added css rule for screen size

### DIFF
--- a/css/powerthecadets_view.css
+++ b/css/powerthecadets_view.css
@@ -37,3 +37,16 @@ a.ptc-meal-available-link {
 .view .date-nav-wrapper .date-next {
   width: 90px;
 }
+
+/* Set city names to a font-size relative to calendar day width.
+   Reference: "Font size as percentage of width" at https://app.asana.com/0/241603776072319/1113153301334740
+*/
+@media only screen and (max-width: 600px) {
+  div.views-field-nothing h3 {
+    font-size: 1.25vw;
+  }
+
+  div.ptc-meal-button {
+    font-size: 1.25vw;
+  }
+}


### PR DESCRIPTION
I believe this finishes out the responsive issue while preserving the existing desktop layout.

Applying your rule to only smaller screens does the trick. I also added the same rule to ptc-meal-button elements, which now fits the entire calendar on mobile devices.